### PR TITLE
fix appsteam for flathub

### DIFF
--- a/share/metainfo/io.github.smcameron.space-nerds-in-space.metainfo.xml.template
+++ b/share/metainfo/io.github.smcameron.space-nerds-in-space.metainfo.xml.template
@@ -41,13 +41,15 @@
   <screenshots>
     <screenshot type="default">
       <image>https://spacenerdsinspace.com/snis-asset-archives/screenshots/Screenshot%20from%202025-02-03%2011-04-59.png</image>
+      <caption>View of the weapons officer's screen.</caption>
     </screenshot>
      <screenshot type="default">
       <image>https://spacenerdsinspace.com/snis-asset-archives/screenshots/Screenshot%20from%202025-02-03%2011-05-50.png</image>
+      <caption>View of the navigation officer's screen.</caption>
     </screenshot>
-
      <screenshot type="default">
       <image>https://spacenerdsinspace.com/snis-asset-archives/screenshots/Screenshot%20from%202025-02-03%2011-08-35.png</image>
+      <caption>View of the science officer's screen.</caption>
     </screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
Latest flathub build insists we have image captions. I have added captions

Latest flathub build insists we have image captions:

flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo
 in dir /srv/buildbot/worker/build-aarch64-3/build (timeout 1200 secs)
 watching logfiles {}
 argv: b'flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo'
 using PTY: False
{
    "errors": [
        "appstream-failed-validation"
    ],
    "warnings": [
        "appstream-screenshot-missing-caption"
    ],
    "appstream": [
        "W: io.github.smcameron.space-nerds-in-space:20: release-type-invalid desktop-application"
    ],
    "info": [
        "appstream-failed-validation: Metainfo file /tmp/tmpipfmmow9/metainfo/io.github.smcameron.space-nerds-in-space.metainfo.xml has failed validation. Please see the errors in appstream block",
        "appstream-screenshot-missing-caption: One or more screenshots are missing captions in the Metainfo file"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
program finished with exit code 1
elapsedTime=9.890342

Signed-off-by: vpelss@gmail.com


